### PR TITLE
Bump inventory module

### DIFF
--- a/bionic/inventory/terraform.tfvars
+++ b/bionic/inventory/terraform.tfvars
@@ -1,7 +1,7 @@
 # Terragrunt config
 terragrunt = {
   terraform {
-    source = "github.com/gsa/datagov-infrastructure-modules.git//inventory?ref=v2.0.0"
+    source = "github.com/gsa/datagov-infrastructure-modules.git//inventory?ref=v2.1.0"
 
     extra_arguments "secrets" {
       commands = ["${get_terraform_commands_that_need_vars()}"]

--- a/ci/inventory/terraform.tfvars
+++ b/ci/inventory/terraform.tfvars
@@ -1,7 +1,7 @@
 # Terragrunt config
 terragrunt = {
   terraform {
-    source = "github.com/gsa/datagov-infrastructure-modules.git//inventory?ref=v2.0.1"
+    source = "github.com/gsa/datagov-infrastructure-modules.git//inventory?ref=v2.1.0"
 
     extra_arguments "secrets" {
       commands = ["${get_terraform_commands_that_need_vars()}"]


### PR DESCRIPTION
Supports the instance_type variable and sets the default to t3.small which is
needed for memory required during CKAN install.