### PR TITLE
Bump instance type for CKAN instances

### DIFF
--- a/bionic/catalog/terraform.tfvars
+++ b/bionic/catalog/terraform.tfvars
@@ -25,3 +25,4 @@ terragrunt = {
 env        = "bionic"
 key_name   = "datagov-sandbox"
 ami_filter_name = "ubuntu/images/*ubuntu-bionic-18.04-amd64-server-*"
+web_instance_type = "t3.medium"

--- a/bionic/inventory/terraform.tfvars
+++ b/bionic/inventory/terraform.tfvars
@@ -25,3 +25,4 @@ terragrunt = {
 env        = "bionic"
 key_name   = "datagov-sandbox"
 ami_filter_name = "ubuntu/images/*ubuntu-bionic-18.04-amd64-server-*"
+web_instance_type = "t3.medium"

--- a/ci/catalog/terraform.tfvars
+++ b/ci/catalog/terraform.tfvars
@@ -25,3 +25,4 @@ terragrunt = {
 env        = "ci"
 key_name   = "datagov-sandbox"
 ami_filter_name = "ubuntu/images/*ubuntu-trusty-14.04-amd64-server-*"
+web_instance_type = "t3.medium"

--- a/ci/inventory/terraform.tfvars
+++ b/ci/inventory/terraform.tfvars
@@ -25,3 +25,4 @@ terragrunt = {
 env        = "ci"
 key_name   = "datagov-sandbox"
 ami_filter_name = "ubuntu/images/*ubuntu-trusty-14.04-amd64-server-*"
+web_instance_type = "t3.medium"


### PR DESCRIPTION
Default is t3.small.

Still seeing playbooks fail on CKAN instances during the pip install.