### PR TITLE
Add to the basic developer capabilities

### DIFF
--- a/iam/developers.tf
+++ b/iam/developers.tf
@@ -14,3 +14,34 @@ resource "aws_iam_policy" "enforce_mfa" {
   # https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_examples_aws_my-sec-creds-self-manage.html
   policy = file("files/aws_sec_creds_self_manage.json")
 }
+
+resource "aws_iam_group_policy_attachment" "developers_elb_full" {
+  group      = aws_iam_group.developers.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2FullAccess"
+}
+
+resource "aws_iam_group_policy_attachment" "developers_ec2_full" {
+  group      = aws_iam_group.developers.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2FullAccess"
+}
+
+resource "aws_iam_group_policy_attachment" "developers_efs_full" {
+  group      = aws_iam_group.developers.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonElasticFileSystemFullAccess"
+}
+
+resource "aws_iam_group_policy_attachment" "developers_rds_full" {
+  group      = aws_iam_group.developers.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonRDSFullAccess"
+}
+
+resource "aws_iam_group_policy_attachment" "developers_route53_full" {
+  group      = aws_iam_group.developers.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonRoute53FullAccess"
+}
+
+resource "aws_iam_group_policy_attachment" "developers_s3_full" {
+  group      = aws_iam_group.developers.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonS3FullAccess"
+}
+


### PR DESCRIPTION
`terraform plan` says: 

```
Terraform will perform the following actions:

  # aws_iam_group_policy_attachment.developers_ec2_full will be created
  + resource "aws_iam_group_policy_attachment" "developers_ec2_full" {
      + group      = "developers"
      + id         = (known after apply)
      + policy_arn = "arn:aws:iam::aws:policy/AmazonEC2FullAccess"
    }

  # aws_iam_group_policy_attachment.developers_efs_full will be created
  + resource "aws_iam_group_policy_attachment" "developers_efs_full" {
      + group      = "developers"
      + id         = (known after apply)
      + policy_arn = "arn:aws:iam::aws:policy/AmazonElasticFileSystemFullAccess"
    }

  # aws_iam_group_policy_attachment.developers_elb_full will be created
  + resource "aws_iam_group_policy_attachment" "developers_elb_full" {
      + group      = "developers"
      + id         = (known after apply)
      + policy_arn = "arn:aws:iam::aws:policy/AmazonEC2FullAccess"
    }

  # aws_iam_group_policy_attachment.developers_rds_full will be created
  + resource "aws_iam_group_policy_attachment" "developers_rds_full" {
      + group      = "developers"
      + id         = (known after apply)
      + policy_arn = "arn:aws:iam::aws:policy/AmazonRDSFullAccess"
    }

  # aws_iam_group_policy_attachment.developers_route53_full will be created
  + resource "aws_iam_group_policy_attachment" "developers_route53_full" {
      + group      = "developers"
      + id         = (known after apply)
      + policy_arn = "arn:aws:iam::aws:policy/AmazonRoute53FullAccess"
    }

  # aws_iam_group_policy_attachment.developers_s3_full will be created
  + resource "aws_iam_group_policy_attachment" "developers_s3_full" {
      + group      = "developers"
      + id         = (known after apply)
      + policy_arn = "arn:aws:iam::aws:policy/AmazonS3FullAccess"
    }

Plan: 6 to add, 0 to change, 0 to destroy.
```