### PR TITLE
[inventory] Fix Ansible groups

### DIFF
--- a/ci/inventory-2-8/terraform.tfvars
+++ b/ci/inventory-2-8/terraform.tfvars
@@ -26,7 +26,7 @@ terragrunt = {
 # Module config
 env        = "ci"
 key_name   = "datagov-sandbox"
-ansible_group = "inventory_web,inventory_web_2_8"
+ansible_group = "inventory_web,inventory_web_2_8,v2"
 db_name = "inventory_db_2_8"
 web_instance_name = "inventory-2-8"
 ami_filter_name = "ubuntu/images/*ubuntu-bionic-18.04-amd64-server-*"

--- a/ci/inventory-2-8/terraform.tfvars
+++ b/ci/inventory-2-8/terraform.tfvars
@@ -26,7 +26,7 @@ terragrunt = {
 # Module config
 env        = "ci"
 key_name   = "datagov-sandbox"
-ansible_group = "inventory-web,inventory-web-2-8"
+ansible_group = "inventory_web,inventory_web_2_8"
 db_name = "inventory_db_2_8"
 web_instance_name = "inventory-2-8"
 ami_filter_name = "ubuntu/images/*ubuntu-bionic-18.04-amd64-server-*"


### PR DESCRIPTION
- Use underscores to match how Ansible's dynamic inventory parses tags
- Specify v2 inventory group for Bionic