### PR TITLE
[iam] allow GetHostedZone on all zones

### DIFF
--- a/iam/files/aws_iam_policy_ci_terraform.json
+++ b/iam/files/aws_iam_policy_ci_terraform.json
@@ -122,7 +122,7 @@
             ],
             "Resource": [
                 "arn:aws:route53:::change/*",
-                "arn:aws:route53:::hostedzone/Z2QMRHTV5AP7G6"
+                "arn:aws:route53:::hostedzone/*"
             ]
         },
         {


### PR DESCRIPTION
Terraform can create new zones, so maintaining individual zones in the IAM
policy isn't what we want.