### PR TITLE
Update security groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,3 +89,32 @@ When making changes to the
 [datagov-infrastructure-modules](https://github.com/GSA/datagov-infrastructure-modules),
 you may have to change the source directory on terragrunt to be a local path.
 See [inventory 2.8](./ci/inventory-2-8/tarraform.tfvars#4) for an example.
+
+
+## Continuous delivery
+
+We use CircleCI for continuous integration and delivery.
+
+You must configure CircleCI with secrets in order to apply the terraform files.
+
+- AWS IAM credentials of the deploy user
+- Application secrets to set (e.g. database passwords)
+- Root ssh keys in order to provision through the jumpbox
+
+First, set these [environment variables in
+CircleCI](https://app.circleci.com/settings/project/github/GSA/datagov-infrastructure-live/environment-variables)
+using the credentials from the deploy user (`datagov-ci`):
+
+- `AWS_ACCESS_KEY_ID`
+- `AWS_SECRET_ACCESS_KEY`
+
+Next, set any `TF_VAR_*` [environment variables in
+CircleCI](https://app.circleci.com/settings/project/github/GSA/datagov-infrastructure-live/environment-variables)
+from your `.env`. Reach out to a team member if you are missing any or pull them
+from the terraform state (`terraform output`).
+
+Finally, add the [root ssh
+key](https://drive.google.com/drive/folders/10-hk-IqA0jQAW6727pKmW46EF-nHiNLr)
+(datagov-sandbox) in
+[CircleCI](https://app.circleci.com/settings/project/github/GSA/datagov-infrastructure-live/ssh)
+under "additional keys".

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Name | Description | Terraform | Terragrunt | Jumpbox
 [`ci`](ci/README.md)       | WIP continuous integration environment automatically runs datagov-deploy playbooks from `develop`. | v0.11 | v0.18 | jump.ci.datagov.us
 [`ckan-cloud-dev`](ckan-cloud-dev/README.md) | Development environment for the CKAN Cloud project. | v0.12 | N | N/A
 [`iam`](iam/README.md) | Global "environment" that applies IAM settings to to the sandbox account. | v0.12 | N | N/A
+[`sandbox`](sandbox/README.md) | WIP continuous integration environment automatically runs datagov-deploy playbooks from `develop`. | v0.12 | N | jump.sandbox.datagov.us
 
 
 ## Development

--- a/ci/env.sample
+++ b/ci/env.sample
@@ -1,4 +1,5 @@
 export TF_VAR_catalog_db_password=
 export TF_VAR_dashboard_db_password=
 export TF_VAR_inventory_db_password=
+export TF_VAR_inventory_2_8_db_password=
 export TF_VAR_wordpress_db_password=

--- a/docs/datagov-deploy-environments.md
+++ b/docs/datagov-deploy-environments.md
@@ -28,9 +28,10 @@ not.
 
 ### Root ssh key
 
-The initial provisioning requires SSH access to the jumpbox. Since the jumpbox playbooks have
-not been run, you must use the environment's root SSH key. Please see a team
-member for access.
+The initial provisioning requires SSH access to the jumpbox. Since the jumpbox
+playbooks have not been run, you must use the environment's [root SSH
+key](https://drive.google.com/drive/folders/10-hk-IqA0jQAW6727pKmW46EF-nHiNLr).
+Please see a team member for access.
 
 Add the SSH key to your SSH agent.
 

--- a/env.sample
+++ b/env.sample
@@ -12,6 +12,7 @@
 export TF_VAR_catalog_db_password=
 export TF_VAR_dashboard_db_password=
 export TF_VAR_inventory_db_password=
+export TF_VAR_inventory_2_8_db_password=
 export TF_VAR_wordpress_db_password=
 
 

--- a/sandbox/README.md
+++ b/sandbox/README.md
@@ -1,0 +1,120 @@
+# sandbox
+
+This environment keeps parity with the BSP environments. The purpose is to act
+as a continuous integration environment to test playbook live in a multi-host
+environment.
+
+
+## Usage
+
+Make sure you've already followed the common setup instructions in the top-level
+[README](../README.md).
+
+
+### Requirements
+
+- [Terraform](https://www.terraform.io/intro/getting-started/install.html) v0.12
+
+
+### Root ssh key
+
+The initial provisioning requires SSH access to the jumpbox. Since the jumpbox
+playbooks have not been run, you must use the environment's [root SSH
+key](https://drive.google.com/drive/folders/10-hk-IqA0jQAW6727pKmW46EF-nHiNLr).
+Please see a team member for access.
+
+Add the SSH key to your SSH agent.
+
+    ssh-add ~/.ssh/datagov-sandbox
+
+You must setup ssh-agent forwarding. Add this snippet to your SSH config.
+
+```
+# ~/.ssh/config
+
+Host *.datagov.us
+    ForwardAgent yes
+```
+
+
+### Secrets
+
+Copy the `env.sample` to `.env`. Then you can populate these secrets from the
+Terraform state file. These secrets will also exist in the Ansible vault.
+
+    $ terraform refresh
+    $ terraform output
+
+
+## Ansible usage
+
+Once the environment is provisioned with Terraform, you can connect to the
+jumpbox to apply Ansible playbooks just as we do in the BSP environments.
+
+
+### Configure SSH for jumpbox
+
+Forward your ssh agent so that you have access to the SSH key to connect to
+other instances. Consider adding this to your `~/.ssh/config`.
+
+```
+Host jump.ci.datagov.us jump.bionic.datagov.us
+    User <yourusername>
+    ForwardAgent yes
+    IdentityFile ~/.ssh/<your-datagov-deploy-key>
+```
+
+Connect to the jumpbox.
+
+    $ ssh $jumpbox_dns
+
+The jumpbox dns is an output variable in the jumpbox module.
+
+    $ terraform output
+
+
+### Bootstraping the jumpbox
+
+When the jumpbox is first created, you'll need to bootstrap it to run ansible.
+You can copy/paste these scripts into your terminal. All commands should be run
+from the jumpbox.
+
+First, install pyenv.
+
+```bash
+git clone https://github.com/pyenv/pyenv.git ~/.pyenv
+echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc
+echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc
+echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc
+echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n  eval "$(pyenv init -)"\nfi' >> ~/.bashrc
+source ~/.bashrc
+```
+
+Setup SSH.
+
+```bash
+cat <<EOF > ~/.ssh/config
+StrictHostKeyChecking=no
+
+Host *.datagov.us
+    User ubuntu
+    IdentityFile ~/.ssh/authorized_keys
+EOF
+```
+
+Then setup datagov-deploy.
+
+```bash
+git clone https://github.com/GSA/datagov-deploy.git
+cd datagov-deploy
+pip3 install --user pipenv
+pipenv sync
+pipenv run make update-vendor-force
+```
+
+Symlink the inventory to avoid having to specify it with ansible.
+
+```bash
+sudo mkdir /etc/ansible
+sudo ln -s /home/ubuntu/datagov-deploy/ansible/inventories/sandbox /etc/ansible/hosts
+```

--- a/sandbox/catalog.tf
+++ b/sandbox/catalog.tf
@@ -16,8 +16,8 @@ module "catalog" {
   vpc_id                  = module.vpc.vpc_id
   web_instance_type       = "t3.medium"
 
-  # TODO this should be part of the module
   security_groups = [
+    module.vpc.security_group_id,
     module.jumpbox.security_group_id,
     module.solr.security_group_id,
   ]

--- a/sandbox/dashboard.tf
+++ b/sandbox/dashboard.tf
@@ -8,8 +8,12 @@ module "dashboard" {
   dns_zone_public       = module.vpc.dns_zone_public
   env                   = var.env
   key_name              = var.key_name
-  security_groups       = [module.jumpbox.security_group_id]
   subnets_private       = module.vpc.private_subnets
   subnets_public        = module.vpc.public_subnets
   vpc_id                = module.vpc.vpc_id
+
+  security_groups       = [
+    module.vpc.security_group_id,
+    module.jumpbox.security_group_id,
+  ]
 }

--- a/sandbox/inventory-2-8.tf
+++ b/sandbox/inventory-2-8.tf
@@ -16,6 +16,7 @@ module "inventory_2_8" {
   vpc_id                = module.vpc.vpc_id
 
   security_groups = [
+    module.vpc.security_group_id,
     module.jumpbox.security_group_id,
     module.solr.security_group_id,
   ]

--- a/sandbox/inventory.tf
+++ b/sandbox/inventory.tf
@@ -16,6 +16,7 @@ module "inventory" {
   vpc_id                = module.vpc.vpc_id
 
   security_groups = [
+    module.vpc.security_group_id,
     module.jumpbox.security_group_id,
     module.solr.security_group_id,
   ]

--- a/sandbox/jenkins.tf
+++ b/sandbox/jenkins.tf
@@ -8,7 +8,11 @@ module "jenkins" {
   ebs_size           = 60
   env                = var.env
   key_name           = var.key_name
-  security_groups    = [module.jumpbox.security_group_id]
   subnets            = module.vpc.public_subnets
   vpc_id             = module.vpc.vpc_id
+
+  security_groups    = [
+    module.vpc.security_group_id,
+    module.jumpbox.security_group_id
+  ]
 }

--- a/sandbox/jumpbox.tf
+++ b/sandbox/jumpbox.tf
@@ -8,4 +8,8 @@ module "jumpbox" {
   key_name         = var.key_name
   public_subnets   = module.vpc.public_subnets
   vpc_id           = module.vpc.vpc_id
+
+  security_groups = [
+    module.vpc.security_group_id,
+  ]
 }

--- a/sandbox/outputs.tf
+++ b/sandbox/outputs.tf
@@ -3,9 +3,19 @@ output "catalog_db_password" {
   value     = module.catalog.db_password
 }
 
+output "catalog_db_host" {
+  sensitive = true
+  value     = module.catalog.db_server
+}
+
 output "dashboard_db_password" {
   sensitive = true
   value     = module.dashboard.db_password
+}
+
+output "dashboard_db_host" {
+  sensitive = true
+  value     = module.dashboard.db_server
 }
 
 output "inventory_db_password" {
@@ -13,9 +23,19 @@ output "inventory_db_password" {
   value     = module.inventory.db_password
 }
 
+output "inventory_db_host" {
+  sensitive = true
+  value     = module.inventory.db_server
+}
+
 output "inventory_2_8_db_password" {
   sensitive = true
   value     = module.inventory_2_8.db_password
+}
+
+output "inventory_2_8_db_host" {
+  sensitive = true
+  value     = module.inventory_2_8.db_server
 }
 
 output "jumpbox_dns" {
@@ -25,4 +45,9 @@ output "jumpbox_dns" {
 output "wordpress_db_password" {
   sensitive = true
   value     = module.wordpress.db_password
+}
+
+output "wordpress_db_host" {
+  sensitive = true
+  value     = module.wordpress.db_server
 }

--- a/sandbox/outputs.tf
+++ b/sandbox/outputs.tf
@@ -18,6 +18,10 @@ output "inventory_2_8_db_password" {
   value     = module.inventory_2_8.db_password
 }
 
+output "jumpbox_dns" {
+  value     = module.jumpbox.jumpbox_dns
+}
+
 output "wordpress_db_password" {
   sensitive = true
   value     = module.wordpress.db_password

--- a/sandbox/solr.tf
+++ b/sandbox/solr.tf
@@ -7,7 +7,11 @@ module "solr" {
   ebs_size           = 20
   env                = var.env
   key_name           = var.key_name
-  security_groups    = [module.jumpbox.security_group_id]
   subnets            = module.vpc.private_subnets
   vpc_id             = module.vpc.vpc_id
+
+  security_groups    = [
+    module.vpc.security_group_id,
+    module.jumpbox.security_group_id
+  ]
 }

--- a/sandbox/wordpress.tf
+++ b/sandbox/wordpress.tf
@@ -10,6 +10,10 @@ module "wordpress" {
   key_name              = var.key_name
   subnets_private       = module.vpc.private_subnets
   subnets_public        = module.vpc.public_subnets
-  security_groups       = [module.jumpbox.security_group_id]
   vpc_id                = module.vpc.vpc_id
+
+  security_groups       = [
+    module.vpc.security_group_id,
+    module.jumpbox.security_group_id,
+  ]
 }


### PR DESCRIPTION
Be explicit about specifying security group to instances.

This removes an implicit dependency on `data` sources expecting security groups
to pre-exist and then failing because they haven't been created yet. You only
notice this if you `terraform destroy` everything and then re-create everything
from scratch. Making the security groups explicit helps terraform to understand
the dependencies on different modules.