### PR TITLE
Bump catalog module to pick up security group fix

### DIFF
--- a/sandbox/catalog-next.tf
+++ b/sandbox/catalog-next.tf
@@ -1,5 +1,5 @@
 module "catalog_next" {
-  source = "github.com/gsa/datagov-infrastructure-modules.git//modules/catalog?ref=v3.7.0"
+  source = "github.com/gsa/datagov-infrastructure-modules.git//modules/catalog?ref=v3.7.1"
 
   bastion_host            = module.jumpbox.jumpbox_dns
   database_subnet_group   = module.vpc.database_subnet_group


### PR DESCRIPTION
Catalog ("classic" and "next") web instances were not assigned to the appropriate web security group.  This didn't impact "classic", but it broke "next" because the web security group was used to specify an ingress rule for the redis service.