### PR TITLE
update ref for fgdc2iso port 80 change

### DIFF
--- a/sandbox/catalog.tf
+++ b/sandbox/catalog.tf
@@ -1,5 +1,5 @@
 module "catalog" {
-  source = "github.com/gsa/datagov-infrastructure-modules.git//modules/catalog?ref=v4.1.0"
+  source = "github.com/gsa/datagov-infrastructure-modules.git//modules/catalog?ref=bug%2Ffgdc2iso-no-port-80"
 
   # Catalog still uses Trusty (v1)
   ami_filter_name         = "ubuntu/images/*ubuntu-trusty-14.04-amd64-server-*"


### PR DESCRIPTION
go together with https://github.com/GSA/datagov-infrastructure-modules/pull/73
branch name placeholder for tag number.