### PR TITLE
Prevent "region not set" errors

### DIFF
--- a/env.sample
+++ b/env.sample
@@ -27,4 +27,5 @@ export AWS_ACCESS_KEY_ID=
 export AWS_SECRET_ACCESS_KEY=
 export AWS_MFA_DEVICE_ARN=
 
+export AWS_DEFAULT_REGION=us-east-1
 eval "$(./bin/aws_temp_credentials.sh)"


### PR DESCRIPTION
This probably isn't the right fix, but it resolves an issue that folks run into
where the aws provider in the modules doesn't know what region to use.

I think the real issue is that we need to use the provider defined in main.tf
and "pass" it to the modules.