### PR TITLE
Temporarily pin CI to use Terraform v0.12.29

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ version: 2
 jobs:
   iam-validate:
     docker:
-      - image: hashicorp/terraform:latest
+      - image: hashicorp/terraform:0.12.29
         entrypoint: ["/bin/sh"]
     environment:
       terraform_directory: iam
@@ -45,7 +45,7 @@ jobs:
 
   iam-plan:
     docker:
-      - image: hashicorp/terraform:latest
+      - image: hashicorp/terraform:0.12.29
         entrypoint: ["/bin/sh"]
     environment:
       terraform_directory: iam
@@ -53,7 +53,7 @@ jobs:
 
   iam-apply:
     docker:
-      - image: hashicorp/terraform:latest
+      - image: hashicorp/terraform:0.12.29
         entrypoint: ["/bin/sh"]
     environment:
       terraform_directory: iam
@@ -61,7 +61,7 @@ jobs:
 
   sandbox-validate:
     docker:
-      - image: hashicorp/terraform:latest
+      - image: hashicorp/terraform:0.12.29
         entrypoint: ["/bin/sh"]
     environment:
       terraform_directory: sandbox
@@ -70,7 +70,7 @@ jobs:
 
   sandbox-plan:
     docker:
-      - image: hashicorp/terraform:latest
+      - image: hashicorp/terraform:0.12.29
         entrypoint: ["/bin/sh"]
     environment:
       terraform_directory: sandbox
@@ -79,7 +79,7 @@ jobs:
 
   sandbox-apply:
     docker:
-      - image: hashicorp/terraform:latest
+      - image: hashicorp/terraform:0.12.29
         entrypoint: ["/bin/sh"]
     environment:
       terraform_directory: sandbox


### PR DESCRIPTION
This solves two short-term problems:

1. Our state file was written with 0.12.29, but the terraform:latest tag still
   points to 0.12.28 and CI refuses to touch the state file.
2. Terraform 0.13 is in RC, and we probably don't want to jump to it
   immediately. There were breaking changes from 0.11 -> 0.12 and we want to
   avoid rushing into that.

The "right" fix is probably to just add docker/docker-compose so that we're
using the same terraform versions in local development and CI.