### PR TITLE
add steps to install and use python 3.6.8

### DIFF
--- a/sandbox/README.md
+++ b/sandbox/README.md
@@ -109,7 +109,8 @@ Then setup datagov-deploy.
 git clone https://github.com/GSA/datagov-deploy.git
 cd datagov-deploy
 pip3 install --user pipenv
-pipenv sync
+pyenv install 3.6.8
+pipenv sync --python=3.6.8
 pipenv run make vendor
 ```
 


### PR DESCRIPTION
When setting up virtualenv, pipenv ignores .python-version set by pyenv. It ends up using system newer version of python3. We have to specify the python version in pipenv command. 

References:
https://github.com/pypa/pipenv/issues/4339
https://pipenv.pypa.io/en/latest/diagnose/#pipenv-does-not-respect-pyenvs-global-and-local-python-versions