### PR TITLE
Resolve error deleting IAM user

### DIFF
--- a/iam/files/aws_iam_policy_ci_terraform.json
+++ b/iam/files/aws_iam_policy_ci_terraform.json
@@ -42,6 +42,7 @@
                 "iam:ListMFADevices",
                 "iam:ListPolicies",
                 "iam:ListPolicyVersions",
+                "iam:ListSigningCertificates",
                 "iam:ListSSHPublicKeys",
                 "iam:ListUserPolicies",
                 "iam:ListUsers",


### PR DESCRIPTION
Resolves error applying a delete user plan in CI
https://app.circleci.com/pipelines/github/GSA/datagov-infrastructure-live/344/workflows/5c895ea2-b3a4-446f-adeb-33ee6cda44bd/jobs/2134

```
Error: error removing IAM User (paul.walker@datopian.com) signing certificate: Error removing signing certificates of user paul.walker@datopian.com: AccessDenied: User: arn:aws:iam::587807691409:user/datagov-ci is not authorized to perform: iam:ListSigningCertificates on resource: user paul.walker@datopian.com
	status code: 403, request id: 3e317cbb-3241-4350-868c-47db828f01ff
```