### PR TITLE
update ckan to use latest modules

### DIFF
--- a/sandbox/catalog-next.tf
+++ b/sandbox/catalog-next.tf
@@ -1,5 +1,5 @@
 module "catalog_next" {
-  source = "github.com/gsa/datagov-infrastructure-modules.git//modules/catalog?ref=v4.1.1"
+  source = "github.com/gsa/datagov-infrastructure-modules.git//modules/catalog?ref=v4.2.0"
 
   bastion_host            = module.jumpbox.jumpbox_dns
   database_subnet_group   = module.vpc.database_subnet_group

--- a/sandbox/catalog.tf
+++ b/sandbox/catalog.tf
@@ -1,5 +1,5 @@
 module "catalog" {
-  source = "github.com/gsa/datagov-infrastructure-modules.git//modules/catalog?ref=v4.1.2"
+  source = "github.com/gsa/datagov-infrastructure-modules.git//modules/catalog?ref=v4.2.0"
 
   # Catalog still uses Trusty (v1)
   ami_filter_name         = "ubuntu/images/*ubuntu-trusty-14.04-amd64-server-*"

--- a/sandbox/inventory-next.tf
+++ b/sandbox/inventory-next.tf
@@ -1,5 +1,5 @@
 module "inventory_next" {
-  source = "github.com/gsa/datagov-infrastructure-modules.git//modules/inventory?ref=v4.1.3"
+  source = "github.com/gsa/datagov-infrastructure-modules.git//modules/inventory?ref=v4.2.0"
 
   ansible_group         = "inventory_web,inventory_web_next,v2"
   bastion_host          = module.jumpbox.jumpbox_dns

--- a/sandbox/inventory.tf
+++ b/sandbox/inventory.tf
@@ -1,5 +1,5 @@
 module "inventory" {
-  source = "github.com/gsa/datagov-infrastructure-modules.git//modules/inventory?ref=v4.1.3"
+  source = "github.com/gsa/datagov-infrastructure-modules.git//modules/inventory?ref=v4.2.0"
 
   # Inventory still uses Trusty (v1)
   ami_filter_name       = "ubuntu/images/*ubuntu-trusty-14.04-amd64-server-*"


### PR DESCRIPTION
Making sure ckan apps are good with latest changes before making LoadBalancer http->https.