### PR TITLE
catalog-next db 30GB

### DIFF
--- a/sandbox/catalog-next.tf
+++ b/sandbox/catalog-next.tf
@@ -3,6 +3,7 @@ module "catalog_next" {
 
   bastion_host            = module.jumpbox.jumpbox_dns
   database_subnet_group   = module.vpc.database_subnet_group
+  db_allocated_storage    = "30"
   db_name                 = "catalog_db_next"
   db_password             = var.catalog_next_db_password
   dns_zone_private        = module.vpc.dns_zone_private


### PR DESCRIPTION
Set the DB to be 30GB as what is currently in use, so terraform apply wont try to reduce it to default 20GB and generate error.