### PR TITLE
[jenkins] create a second instance for saml

### DIFF
--- a/sandbox/catalog-next.tf
+++ b/sandbox/catalog-next.tf
@@ -1,6 +1,10 @@
 module "catalog_next" {
   source = "github.com/gsa/datagov-infrastructure-modules.git//modules/catalog?ref=v4.2.1"
 
+  providers = {
+    aws = aws
+  }
+
   bastion_host            = module.jumpbox.jumpbox_dns
   database_subnet_group   = module.vpc.database_subnet_group
   db_allocated_storage    = "30"

--- a/sandbox/catalog.tf
+++ b/sandbox/catalog.tf
@@ -1,6 +1,10 @@
 module "catalog" {
   source = "github.com/gsa/datagov-infrastructure-modules.git//modules/catalog?ref=v4.2.1"
 
+  providers = {
+    aws = aws
+  }
+
   # Catalog still uses Trusty (v1)
   ami_filter_name         = "ubuntu/images/*ubuntu-trusty-14.04-amd64-server-*"
   bastion_host            = module.jumpbox.jumpbox_dns

--- a/sandbox/dashboard.tf
+++ b/sandbox/dashboard.tf
@@ -1,6 +1,10 @@
 module "dashboard" {
   source = "github.com/gsa/datagov-infrastructure-modules.git//modules/dashboard?ref=v3.5.2"
 
+  providers = {
+    aws = aws
+  }
+
   bastion_host          = module.jumpbox.jumpbox_dns
   database_subnet_group = module.vpc.database_subnet_group
   db_password           = var.dashboard_db_password

--- a/sandbox/inventory-next.tf
+++ b/sandbox/inventory-next.tf
@@ -1,6 +1,10 @@
 module "inventory_next" {
   source = "github.com/gsa/datagov-infrastructure-modules.git//modules/inventory?ref=v4.2.1"
 
+  providers = {
+    aws = aws
+  }
+
   ansible_group         = "inventory_web,inventory_web_next,v2"
   bastion_host          = module.jumpbox.jumpbox_dns
   database_subnet_group = module.vpc.database_subnet_group

--- a/sandbox/inventory.tf
+++ b/sandbox/inventory.tf
@@ -1,6 +1,10 @@
 module "inventory" {
   source = "github.com/gsa/datagov-infrastructure-modules.git//modules/inventory?ref=v4.2.1"
 
+  providers = {
+    aws = aws
+  }
+
   # Inventory still uses Trusty (v1)
   ami_filter_name       = "ubuntu/images/*ubuntu-trusty-14.04-amd64-server-*"
   ansible_group         = "inventory_web,v1"

--- a/sandbox/jenkins.tf
+++ b/sandbox/jenkins.tf
@@ -1,5 +1,5 @@
 module "jenkins" {
-  source = "github.com/gsa/datagov-infrastructure-modules.git//modules/jenkins?ref=v4.2.0"
+  source = "github.com/gsa/datagov-infrastructure-modules.git//modules/jenkins?ref=v4.2.2"
 
   providers = {
     aws = aws
@@ -23,7 +23,7 @@ module "jenkins" {
 }
 
 module "jenkins_saml" {
-  source = "github.com/gsa/datagov-infrastructure-modules.git//modules/jenkins?ref=v4.2.0"
+  source = "github.com/gsa/datagov-infrastructure-modules.git//modules/jenkins?ref=v4.2.2"
 
   availability_zones        = module.vpc.azs
   bastion_host              = module.jumpbox.jumpbox_dns

--- a/sandbox/jenkins.tf
+++ b/sandbox/jenkins.tf
@@ -1,6 +1,10 @@
 module "jenkins" {
   source = "github.com/gsa/datagov-infrastructure-modules.git//modules/jenkins?ref=v4.2.0"
 
+  providers = {
+    aws = aws
+  }
+
   availability_zones        = module.vpc.azs
   bastion_host              = module.jumpbox.jumpbox_dns
   default_security_group_id = module.vpc.security_group_id

--- a/sandbox/jenkins.tf
+++ b/sandbox/jenkins.tf
@@ -1,5 +1,5 @@
 module "jenkins" {
-  source = "github.com/gsa/datagov-infrastructure-modules.git//modules/jenkins?ref=v4.0.2"
+  source = "github.com/gsa/datagov-infrastructure-modules.git//modules/jenkins?ref=v4.2.0"
 
   availability_zones        = module.vpc.azs
   bastion_host              = module.jumpbox.jumpbox_dns
@@ -9,6 +9,28 @@ module "jenkins" {
   ebs_size                  = 60
   env                       = var.env
   key_name                  = var.key_name
+  subnets_private           = module.vpc.private_subnets
+  subnets_public            = module.vpc.public_subnets
+  vpc_id                    = module.vpc.vpc_id
+
+  security_groups = [
+    module.vpc.security_group_id,
+  ]
+}
+
+module "jenkins_saml" {
+  source = "github.com/gsa/datagov-infrastructure-modules.git//modules/jenkins?ref=v4.2.0"
+
+  availability_zones        = module.vpc.azs
+  bastion_host              = module.jumpbox.jumpbox_dns
+  default_security_group_id = module.vpc.security_group_id
+  dns_zone_private          = module.vpc.dns_zone_private
+  dns_zone_public           = module.vpc.dns_zone_public
+  ebs_size                  = 8
+  env                       = var.env
+  key_name                  = var.key_name
+  instance_name_format      = "jenkins-saml%dtf"
+  name                      = "jenkins-saml"
   subnets_private           = module.vpc.private_subnets
   subnets_public            = module.vpc.public_subnets
   vpc_id                    = module.vpc.vpc_id

--- a/sandbox/jumpbox.tf
+++ b/sandbox/jumpbox.tf
@@ -1,6 +1,10 @@
 module "jumpbox" {
   source = "github.com/gsa/datagov-infrastructure-modules.git//modules/jumpbox?ref=v3.5.0"
 
+  providers = {
+    aws = aws
+  }
+
   ami_filter_name           = var.ami_filter_name
   default_security_group_id = module.vpc.security_group_id
   dns_zone_public           = module.vpc.dns_zone_public

--- a/sandbox/solr.tf
+++ b/sandbox/solr.tf
@@ -1,6 +1,10 @@
 module "solr" {
   source = "github.com/gsa/datagov-infrastructure-modules.git//modules/solr?ref=v3.0.0"
 
+  providers = {
+    aws = aws
+  }
+
   availability_zones = module.vpc.azs
   bastion_host       = module.jumpbox.jumpbox_dns
   dns_zone           = module.vpc.dns_zone_private

--- a/sandbox/wordpress.tf
+++ b/sandbox/wordpress.tf
@@ -1,6 +1,10 @@
 module "wordpress" {
   source = "github.com/gsa/datagov-infrastructure-modules.git//modules/wordpress?ref=v3.5.2"
 
+  providers = {
+    aws = aws
+  }
+
   database_subnet_group = module.vpc.database_subnet_group
   db_password           = var.wordpress_db_password
   bastion_host          = module.jumpbox.jumpbox_dns


### PR DESCRIPTION
Create a second instance for saml2 testing. This addresses the duplicate error
that we ran into from
https://github.com/GSA/datagov-infrastructure-live/pull/121 and restores this
work.

This also explicitly passes the aws provider to modules to prevent a "Provider
configuration missing" error.