### PR TITLE
Revert "Update various compliance changes"

### DIFF
--- a/modules/db/rds.tf
+++ b/modules/db/rds.tf
@@ -1,7 +1,6 @@
 resource "aws_db_instance" "default" {
   allocated_storage      = var.db_allocated_storage
   storage_type           = var.db_storage_type
-  storage_encrypted      = true
   engine                 = var.db_engine
   engine_version         = var.db_engine_version
   instance_class         = var.db_instance_class

--- a/modules/redis/main.tf
+++ b/modules/redis/main.tf
@@ -49,7 +49,6 @@ resource "aws_elasticache_replication_group" "redis" {
   security_group_ids            = [aws_security_group.redis[count.index].id]
   subnet_group_name             = aws_elasticache_subnet_group.redis[count.index].name
   transit_encryption_enabled    = var.transit_encryption_enabled
-  at_rest_encryption_enabled    = true
 
   tags = {
     env  = var.env

--- a/modules/s3/main.tf
+++ b/modules/s3/main.tf
@@ -6,21 +6,7 @@ terraform {
 }
 
 
-resource "aws_kms_key" "mykey" {
-  description             = "This key is used to encrypt bucket objects"
-  deletion_window_in_days = 10
-}
-
-
 resource "aws_s3_bucket" "default" {
   bucket = var.bucket_name
   acl    = var.bucket_acl
-  server_side_encryption_configuration {
-    rule {
-      apply_server_side_encryption_by_default {
-        kms_master_key_id = aws_kms_key.mykey.arn
-        sse_algorithm     = "aws:kms"
-      }
-    }
-  }
 }


### PR DESCRIPTION
Reverts GSA/datagov-infrastructure-live#137
IAM role not enabled for encryption setup
RDS size does not support encryption at rest.
System in bad state (applying previous main action did not succeed), need to re-initialize.