### PR TITLE
Update docs, prevent_destroy

### DIFF
--- a/modules/db/rds.tf
+++ b/modules/db/rds.tf
@@ -17,5 +17,10 @@ resource "aws_db_instance" "default" {
     ignore_changes = [
       engine_version,
     ]
+
+    # For most applications, re-creating the database is currently a manual
+    # task. Avoid destroying the database unless we're absolutely sure. Database
+    # must be destroyed manually outside of Terraform.
+    prevent_destroy = true
   }
 }


### PR DESCRIPTION
- Remove mentions of datagov-infrastructure-modules, they are now part of this
  repository.
- Update mentions of iam, they were moved to datagov-iam.
- Replace CircleCI with GH actions.
- Update CI/CD setup secrets.
- Remove references to dynamic Ansible inventory, we've been using a static
  inventory for a while.
- Include a note about reviewing the terraform plan as part of peer review.
- Add prevent_destroy to database instances to prevent an accidental destroy.