### PR TITLE
pin alb module for terraform 0.12

### DIFF
--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -5,15 +5,26 @@ on:
   push:
 
 jobs:
+  # Inspired by https://github.com/terraform-aws-modules/terraform-aws-alb/blob/master/.github/workflows/pre-commit.yml
+  get_modules:
+    name: get matrix build
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: build matrix
+        id: matrix
+        run: |
+          echo "::set-output name=modules::$(make glob-modules)"
+    outputs:
+      modules: ${{ steps.matrix.outputs.modules }}
+
   test:
     name: test
     runs-on: ubuntu-latest
     steps:
       - name: checkout
         uses: actions/checkout@v2
-
-      - name: Test terraform-version
-        uses: dflook/terraform-version@v1
 
       - name: terraform fmt
         uses: dflook/terraform-fmt-check@v1
@@ -25,6 +36,22 @@ jobs:
         with:
           path: .
 
-      # Test modules
-      - name: test
-        run: make test
+  # Probably a better way to do this
+  test-modules:
+    name: test-modules
+    runs-on: ubuntu-latest
+    needs: get_modules
+    strategy:
+      fail-fast: false  # Let's see all the failing modules
+      matrix:
+        module: ${{ fromJSON(needs.get_modules.outputs.modules) }}
+    env:
+      AWS_DEFAULT_REGION: us-east-1
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+
+      - name: terraform validate
+        uses: dflook/terraform-validate@v1
+        with:
+          path: ${{ matrix.module }}

--- a/.github/workflows/commit.yml
+++ b/.github/workflows/commit.yml
@@ -12,6 +12,9 @@ jobs:
       - name: checkout
         uses: actions/checkout@v2
 
+      - name: Test terraform-version
+        uses: dflook/terraform-version@v1
+
       - name: terraform fmt
         uses: dflook/terraform-fmt-check@v1
         with:

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ fmt:
 test: $(SUBDIRS)
 $(SUBDIRS):
 	@echo Testing $@ ...
-  terraform version
+	terraform version
 	terraform init -backend=false $@
 	AWS_DEFAULT_REGION=us-east-1 terraform validate $@
 

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ fmt:
 test: $(SUBDIRS)
 $(SUBDIRS):
 	@echo Testing $@ ...
+  terraform version
 	terraform init -backend=false $@
 	AWS_DEFAULT_REGION=us-east-1 terraform validate $@
 

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,10 @@ fmt:
 	terraform fmt
 	$(foreach subdir, $(SUBDIRS), terraform fmt $(subdir);)
 
+glob-modules:
+	@# Output a comma-separated list of subdirs for CI matrix build
+	@echo $(SUBDIRS) | jq --raw-input --compact-output 'split(" ")'
+
 test: $(SUBDIRS)
 $(SUBDIRS):
 	@echo Testing $@ ...
@@ -30,4 +34,4 @@ $(SUBDIRS):
 	terraform init -backend=false $@
 	AWS_DEFAULT_REGION=us-east-1 terraform validate $@
 
-.PHONY: test $(SUBDIRS)
+.PHONY: glob-modules test $(SUBDIRS)

--- a/modules/catalog/versions.tf
+++ b/modules/catalog/versions.tf
@@ -1,4 +1,4 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = "~> 0.12.0"
 }

--- a/modules/jenkins/lb.tf
+++ b/modules/jenkins/lb.tf
@@ -40,7 +40,8 @@ resource "aws_security_group" "lb" {
 
 module "lb" {
   source  = "terraform-aws-modules/alb/aws"
-  version = "~> 5.3"
+  # Pinning to keep on Terraform 0.12
+  version = "~> 5.3, < 5.14.0"
 
   load_balancer_type = "application"
   name               = "${var.name}-${var.env}-tf"

--- a/modules/jenkins/lb.tf
+++ b/modules/jenkins/lb.tf
@@ -39,7 +39,7 @@ resource "aws_security_group" "lb" {
 }
 
 module "lb" {
-  source  = "terraform-aws-modules/alb/aws"
+  source = "terraform-aws-modules/alb/aws"
   # Pinning to keep on Terraform 0.12
   version = "~> 5.3, < 5.14.0"
 

--- a/modules/web/lb.tf
+++ b/modules/web/lb.tf
@@ -40,7 +40,8 @@ resource "aws_security_group" "lb" {
 
 module "lb" {
   source  = "terraform-aws-modules/alb/aws"
-  version = "~> 5.3"
+  # Pinning to keep on Terraform 0.12
+  version = ">= 5.3.0, < 5.14.0"
 
   load_balancer_type = "application"
   name               = "${var.name}-${var.env}-tf"

--- a/modules/web/lb.tf
+++ b/modules/web/lb.tf
@@ -39,7 +39,7 @@ resource "aws_security_group" "lb" {
 }
 
 module "lb" {
-  source  = "terraform-aws-modules/alb/aws"
+  source = "terraform-aws-modules/alb/aws"
   # Pinning to keep on Terraform 0.12
   version = ">= 5.3.0, < 5.14.0"
 


### PR DESCRIPTION
pin alb module for terraform 0.12 use. See https://github.com/GSA/datagov-infrastructure-live/pull/139/checks?check_run_id=2365487562 for example failures.
Also expect jenkins to be rebuilt, as it has been tainted for re-creation.