### PR TITLE
Specify version constraint for null provider

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -4,6 +4,10 @@ provider "aws" {
   version = "2.70.0"
 }
 
+provider "null" {
+  version = "~> 3.1"
+}
+
 terraform {
   backend "s3" {
     bucket         = "datagov-terraform-state"


### PR DESCRIPTION
This is mostly to work-around and help debug [this GPG verification error](https://github.com/GSA/datagov-infrastructure-live/runs/2443514087?check_suite_focus=true#step:5:76). It's unclear what version of the null provider is being downloaded. This adds a version constraint which is best practice, but also triggers a download of a new version that passes verification 🤷 .