### PR TITLE
Specify latest TLS1.2 ssl policy

### DIFF
--- a/modules/web/lb.tf
+++ b/modules/web/lb.tf
@@ -54,6 +54,7 @@ module "lb" {
     {
       port            = 443
       certificate_arn = aws_acm_certificate.lb.arn
+      ssl_policy      = "ELBSecurityPolicy-TLS-1-2-Ext-2018-06"
     },
   ]
 


### PR DESCRIPTION
Related to https://github.com/GSA/datagov-deploy/issues/2730
Lock down sandbox TLS usage.
Tested manually, site functions as normal and passes compliance tests.