### PR TITLE
Use strict TLS 1.2 policy for ALBs

### DIFF
--- a/modules/web/lb.tf
+++ b/modules/web/lb.tf
@@ -54,7 +54,7 @@ module "lb" {
     {
       port            = 443
       certificate_arn = aws_acm_certificate.lb.arn
-      ssl_policy      = "ELBSecurityPolicy-TLS-1-2-Ext-2018-06"
+      ssl_policy      = "ELBSecurityPolicy-TLS-1-2-2017-01"
     },
   ]
 


### PR DESCRIPTION
Reduce the number of [ciphers supported][1]. Ext supports the same ciphers as
[ELBSecurityPolicy-2016-08][2], which includes "weaker" ciphers.

[1]: https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/elb-security-policy-table.html
[2]: https://aws.amazon.com/about-aws/whats-new/2018/06/application-load-balancer-adds-new-security-policies-including-policy-for-forward-secrecy/
