### PR TITLE
Upgrade aws provider

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,6 @@
 provider "aws" {
   region = "us-east-1"
-  # TODO https://github.com/GSA/datagov-deploy/issues/2032
-  version = "2.70.0"
+  version = "~> 3.31"
 }
 
 provider "null" {

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  region = "us-east-1"
+  region  = "us-east-1"
   version = "~> 3.31"
 }
 

--- a/modules/catalog/main.tf
+++ b/modules/catalog/main.tf
@@ -1,7 +1,6 @@
 terraform {
   required_providers {
-    # TODO https://github.com/GSA/datagov-deploy/issues/2032
-    aws = "~>2.54"
+    aws = "~>3.31"
   }
 }
 

--- a/modules/ckan-cloud/main.tf
+++ b/modules/ckan-cloud/main.tf
@@ -1,7 +1,6 @@
 terraform {
   required_providers {
-    # TODO https://github.com/GSA/datagov-deploy/issues/2032
-    aws = "~>2.54"
+    aws = "~>3.31"
   }
 }
 

--- a/modules/dashboard/main.tf
+++ b/modules/dashboard/main.tf
@@ -1,7 +1,6 @@
 terraform {
   required_providers {
-    # TODO https://github.com/GSA/datagov-deploy/issues/2032
-    aws = "~>2.54"
+    aws = "~>3.31"
   }
 }
 

--- a/modules/db/main.tf
+++ b/modules/db/main.tf
@@ -1,6 +1,5 @@
 terraform {
   required_providers {
-    # TODO https://github.com/GSA/datagov-deploy/issues/2032
-    aws = "~>2.54"
+    aws = "~>3.31"
   }
 }

--- a/modules/inventory/main.tf
+++ b/modules/inventory/main.tf
@@ -1,7 +1,6 @@
 terraform {
   required_providers {
-    # TODO https://github.com/GSA/datagov-deploy/issues/2032
-    aws = "~>2.54"
+    aws = "~>3.31"
   }
 }
 

--- a/modules/jenkins/dns.tf
+++ b/modules/jenkins/dns.tf
@@ -25,10 +25,10 @@ resource "aws_acm_certificate" "lb" {
 
 # DNS record for LB certificate validation
 resource "aws_route53_record" "lb_cert_validation" {
-  name    = aws_acm_certificate.lb.domain_validation_options[0].resource_record_name
-  type    = aws_acm_certificate.lb.domain_validation_options[0].resource_record_type
+  name    = tolist(aws_acm_certificate.lb.domain_validation_options)[0].resource_record_name
+  type    = tolist(aws_acm_certificate.lb.domain_validation_options)[0].resource_record_type
   zone_id = data.aws_route53_zone.public.zone_id
-  records = [aws_acm_certificate.lb.domain_validation_options[0].resource_record_value]
+  records = [tolist(aws_acm_certificate.lb.domain_validation_options)[0].resource_record_value]
   ttl     = 60
 }
 

--- a/modules/jenkins/main.tf
+++ b/modules/jenkins/main.tf
@@ -1,7 +1,6 @@
 terraform {
   required_providers {
-    # TODO https://github.com/GSA/datagov-deploy/issues/2032
-    aws = "~>2.54"
+    aws = "~>3.31"
   }
 }
 

--- a/modules/jumpbox/main.tf
+++ b/modules/jumpbox/main.tf
@@ -1,7 +1,6 @@
 terraform {
   required_providers {
-    # TODO https://github.com/GSA/datagov-deploy/issues/2032
-    aws = "~>2.54"
+    aws = "~>3.31"
   }
 }
 

--- a/modules/mysql/main.tf
+++ b/modules/mysql/main.tf
@@ -1,7 +1,6 @@
 terraform {
   required_providers {
-    # TODO https://github.com/GSA/datagov-deploy/issues/2032
-    aws = "~>2.54"
+    aws = "~>3.31"
   }
 }
 

--- a/modules/postgresdb/main.tf
+++ b/modules/postgresdb/main.tf
@@ -1,7 +1,6 @@
 terraform {
   required_providers {
-    # TODO https://github.com/GSA/datagov-deploy/issues/2032
-    aws = "~>2.54"
+    aws = "~>3.31"
   }
 }
 

--- a/modules/redis/main.tf
+++ b/modules/redis/main.tf
@@ -1,7 +1,6 @@
 terraform {
   required_providers {
-    # TODO https://github.com/GSA/datagov-deploy/issues/2032
-    aws = "~>2.54"
+    aws = "~>3.31"
   }
 }
 

--- a/modules/s3/main.tf
+++ b/modules/s3/main.tf
@@ -1,7 +1,6 @@
 terraform {
   required_providers {
-    # TODO https://github.com/GSA/datagov-deploy/issues/2032
-    aws = "~>2.54"
+    aws = "~>3.31"
   }
 }
 

--- a/modules/solr/main.tf
+++ b/modules/solr/main.tf
@@ -1,7 +1,6 @@
 terraform {
   required_providers {
-    # TODO https://github.com/GSA/datagov-deploy/issues/2032
-    aws = "~>2.54"
+    aws = "~>3.31"
   }
 }
 

--- a/modules/stateful/main.tf
+++ b/modules/stateful/main.tf
@@ -1,7 +1,6 @@
 terraform {
   required_providers {
-    # TODO https://github.com/GSA/datagov-deploy/issues/2032
-    aws = "~>2.54"
+    aws = "~>3.31"
   }
 }
 

--- a/modules/stateless/main.tf
+++ b/modules/stateless/main.tf
@@ -1,7 +1,6 @@
 terraform {
   required_providers {
-    # TODO https://github.com/GSA/datagov-deploy/issues/2032
-    aws = "~>2.54"
+    aws = "~>3.31"
   }
 }
 

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -1,7 +1,6 @@
 terraform {
   required_providers {
-    # TODO https://github.com/GSA/datagov-deploy/issues/2032
-    aws = "~>2.54"
+    aws = "~>3.31"
   }
 }
 

--- a/modules/web/dns.tf
+++ b/modules/web/dns.tf
@@ -25,10 +25,10 @@ resource "aws_acm_certificate" "lb" {
 
 # DNS record for LB certificate validation
 resource "aws_route53_record" "lb_cert_validation" {
-  name    = aws_acm_certificate.lb.domain_validation_options[0].resource_record_name
-  type    = aws_acm_certificate.lb.domain_validation_options[0].resource_record_type
+  name    = tolist(aws_acm_certificate.lb.domain_validation_options)[0].resource_record_name
+  type    = tolist(aws_acm_certificate.lb.domain_validation_options)[0].resource_record_type
   zone_id = data.aws_route53_zone.public.zone_id
-  records = [aws_acm_certificate.lb.domain_validation_options[0].resource_record_value]
+  records = [tolist(aws_acm_certificate.lb.domain_validation_options)[0].resource_record_value]
   ttl     = 60
 }
 

--- a/modules/web/main.tf
+++ b/modules/web/main.tf
@@ -1,7 +1,6 @@
 terraform {
   required_providers {
-    # TODO https://github.com/GSA/datagov-deploy/issues/2032
-    aws = "~>2.54"
+    aws = "~>3.31"
   }
 }
 

--- a/modules/wordpress/main.tf
+++ b/modules/wordpress/main.tf
@@ -1,7 +1,6 @@
 terraform {
   required_providers {
-    # TODO https://github.com/GSA/datagov-deploy/issues/2032
-    aws = "~>2.54"
+    aws = "~>3.31"
   }
 }
 

--- a/ssb.tf
+++ b/ssb.tf
@@ -1,32 +1,36 @@
-resource "aws_route53_record" "ssb" {
-  allow_overwrite = true
-  name            = "ssb"
-  ttl             = 1800
-  type            = "NS"
-  zone_id         = "Z2QMRHTV5AP7G6"
+# The two records for ssb and ssb-staging should not actually be managed here;
+# they belong in the data.gov zone, which is not under Terraform. However,
+# they're recorded here for completeness and for checking against the live values.
 
-  records = [
-    "ns-1147.awsdns-15.org",
-    "ns-1786.awsdns-31.co.uk",
-    "ns-28.awsdns-03.com",
-    "ns-658.awsdns-18.net",
-  ]
-}
+# resource "aws_route53_record" "ssb" {
+#   allow_overwrite = true
+#   name            = "ssb"
+#   ttl             = 1800
+#   type            = "NS"
+#   zone_id         = "Z2QMRHTV5AP7G6"
 
-resource "aws_route53_record" "ssb_staging" {
-  allow_overwrite = true
-  name            = "ssb-staging"
-  ttl             = 1800
-  type            = "NS"
-  zone_id         = "Z2QMRHTV5AP7G6"
+#   records = [
+#     "ns-1147.awsdns-15.org",
+#     "ns-1786.awsdns-31.co.uk",
+#     "ns-28.awsdns-03.com",
+#     "ns-658.awsdns-18.net",
+#   ]
+# }
 
-  records = [
-    "ns-1148.awsdns-15.org",
-    "ns-1937.awsdns-50.co.uk",
-    "ns-377.awsdns-47.com",
-    "ns-965.awsdns-56.net",
-  ]
-}
+# resource "aws_route53_record" "ssb_staging" {
+#   allow_overwrite = true
+#   name            = "ssb-staging"
+#   ttl             = 1800
+#   type            = "NS"
+#   zone_id         = "Z2QMRHTV5AP7G6"
+
+#   records = [
+#     "ns-1148.awsdns-15.org",
+#     "ns-1937.awsdns-50.co.uk",
+#     "ns-377.awsdns-47.com",
+#     "ns-965.awsdns-56.net",
+#   ]
+# }
 
 resource "aws_route53_record" "ssb_dev" {
   allow_overwrite = true


### PR DESCRIPTION
Follows [the Terraform guide for the V3 upgrade](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-3-upgrade).

Relates to https://github.com/GSA/datagov-deploy/issues/2032