### PR TITLE
terraform apply unable to connect to ssh socket

### DIFF
--- a/.github/workflows/apply.yml
+++ b/.github/workflows/apply.yml
@@ -24,6 +24,9 @@ jobs:
   apply:
     runs-on: ubuntu-latest
     name: apply
+    container:
+      volumes:
+        - /tmp:/tmp  # Mount the tmp dir so that the ssh-agent socket is available within the terraform container.
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:


### PR DESCRIPTION
Not sure what changed, but even though the SSH_AUTH_SOCK env variable is
available to terraform, it is unable to connect to the socket. This fix assumes
the socket doesn't exist in the terraform container/action.
